### PR TITLE
engine: capture and report errors rather than aborting on the first error

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -48,8 +48,14 @@ func (m PinMode) String() string {
 }
 
 var (
-	bold  = color.New(color.Bold).SprintFunc()
-	boldf = color.New(color.Bold).SprintfFunc()
+	bold    = color.New(color.Bold).SprintFunc()
+	boldf   = color.New(color.Bold).SprintfFunc()
+	green   = color.New(color.FgGreen).SprintFunc()
+	greenf  = color.New(color.FgGreen).SprintfFunc()
+	red     = color.New(color.FgRed).SprintFunc()
+	redf    = color.New(color.FgRed).SprintfFunc()
+	yellow  = color.New(color.FgYellow).SprintFunc()
+	yellowf = color.New(color.FgYellow).SprintfFunc()
 )
 
 // Engine manages the version upgrade process, from resolving current versions
@@ -84,24 +90,23 @@ func (e *Engine) List(ctx context.Context, dst io.Writer) error {
 	}
 
 	keys := slices.Sorted(maps.Keys(e.root.Workflows))
-	for _, key := range keys {
+	for i, key := range keys {
 		w := e.root.Workflows[key]
 		if len(w.Steps) == 0 {
 			continue
 		}
-		fmt.Fprintln(dst, "")
-		fmt.Fprintf(dst, "in workflow %s", bold(filepath.Base(w.FilePath)))
-		fmt.Fprintln(dst, "")
+		fmt.Fprintf(dst, "workflow %s", bold(filepath.Base(w.FilePath)))
+		fmt.Fprintln(dst)
 		for _, s := range w.Steps {
 			var (
 				current = s.Action.Release
 				latest  = s.Action.UpgradeCandidates.Latest
 				compat  = s.Action.UpgradeCandidates.LatestCompatible
 			)
-			fmt.Fprintf(dst, "  action %s has available versions:", boldf("%s@%s", s.Action.Name, s.Action.Ref))
+			fmt.Fprintf(dst, "  action %s versions:", boldf("%s@%s", s.Action.Name, s.Action.Ref))
 			fmt.Fprintln(dst, "")
 			if !current.Exists() {
-				fmt.Fprintln(dst, "  (could not resolve action versions, unable to pin or upgrade)")
+				fmt.Fprintln(dst, yellow("    (could not resolve action versions, unable to pin or upgrade)"))
 				continue
 			}
 			fmt.Fprintln(dst, "    current: "+current.String())
@@ -109,19 +114,22 @@ func (e *Engine) List(ctx context.Context, dst io.Writer) error {
 				fmt.Fprintln(dst, "    (no upgrade versions found)")
 				continue
 			} else if latest == current {
-				fmt.Fprintln(dst, "    ✓ already using latest version")
+				fmt.Fprintln(dst, green("    ✓ already using latest version"))
 				continue
 			}
 			if compat.Exists() {
 				msg := compat.String()
 				if compat == current {
-					msg = "✓ already using latest compat version"
+					msg = green("✓ already using latest compat version")
 				}
 				fmt.Fprintln(dst, "    compat:  "+msg)
 			}
 			if latest.Exists() {
 				fmt.Fprintln(dst, "    latest:  "+latest.String())
 			}
+		}
+		if i < len(keys)-1 {
+			fmt.Fprintln(dst)
 		}
 	}
 
@@ -252,7 +260,7 @@ func chooseUpgrade(step Step, mode PinMode) Release {
 //
 // Each step is mutated in-place as it is resolved.
 func (e *Engine) resolveSteps(ctx context.Context, mode PinMode) error {
-	e.log.StartSection("resolving action versions for %d step(s) across %d workflow(s) with %d workers", e.root.StepCount(), e.root.WorkflowCount(), e.parallelism)
+	e.log.StartSection("resolving action versions for %d step(s) across %d workflow(s) with %d workers ...", e.root.StepCount(), e.root.WorkflowCount(), e.parallelism)
 
 	// we can skip the extra work of resolving up to two different upgrade
 	// versions if we're only interested in the current versions of our
@@ -273,13 +281,13 @@ func (e *Engine) resolveSteps(ctx context.Context, mode PinMode) error {
 
 			// don't schedule more than N concurrent tasks
 			if err := sem.Acquire(ctx, 1); err != nil {
-				return fmt.Errorf("failed to acquire semaphore: %w", err)
+				e.log.StepError(workflow, step, fmt.Errorf("failed to acquire semaphore: %w", err))
+				continue
 			}
 			g.Go(func() error {
 				defer sem.Release(1)
 				if err := e.resolveStep(ctx, workflow, step, fetchUpgrades); err != nil {
 					e.log.StepError(workflow, step, err)
-					return err
 				}
 				return nil
 			})
@@ -290,6 +298,7 @@ func (e *Engine) resolveSteps(ctx context.Context, mode PinMode) error {
 	}
 
 	e.log.FinishSection("done!")
+	e.log.ShowDiagnistics()
 	return nil
 }
 
@@ -304,14 +313,14 @@ func (e *Engine) resolveStep(ctx context.Context, workflow Workflow, step *Step,
 	e.log.StepInfo(workflow, step, "resolving commit hash for ref %s", step.Action.Ref)
 	commit, err := e.gh.GetCommitHashForRef(ctx, step.Action.Name, step.Action.Ref)
 	if err != nil {
-		return fmt.Errorf("failed to resolve commit hash for ref %s@%s: %w", step.Action.Name, step.Action.Ref, err)
+		return fmt.Errorf("failed to resolve commit hash for ref %s: %w", step.Action.Ref, err)
 	}
 
 	// 2a. attempt to find any semver tags pointing to the resolved commit hash.
 	e.log.StepInfo(workflow, step, "resolving semver tags for commit hash %s", commit)
 	versions, err := e.gh.GetVersionTagsForCommitHash(ctx, step.Action.Name, commit)
 	if err != nil {
-		return fmt.Errorf("failed to fetch version tags for resolved commit %s@%s: %w", step.Action.Name, commit, err)
+		return fmt.Errorf("failed to fetch version tags for resolved commit %s: %w", commit, err)
 	}
 
 	// 2b. it's conceivable that some commits will point to multiple
@@ -347,7 +356,7 @@ func (e *Engine) resolveStep(ctx context.Context, workflow Workflow, step *Step,
 		e.log.StepInfo(workflow, step, "finding upgrade candidates for version %s", step.Action.Release.Version)
 		candidates, err := e.gh.GetUpgradeCandidates(ctx, step.Action.Name, step.Action.Release)
 		if err != nil {
-			return fmt.Errorf("failed to get upgrade candidates for version %s@%s: %w", step.Action.Name, step.Action.Release.Version, err)
+			return fmt.Errorf("failed to get upgrade candidates for version %s: %w", step.Action.Release.Version, err)
 		}
 		step.Action.UpgradeCandidates = candidates
 	}
@@ -399,11 +408,27 @@ const (
 	showCursor     = "\033[?25h"
 )
 
+// Level is a logging/diagnostics level.
+type Level slog.Level
+
+func (l Level) String() string {
+	return slog.Level(l).String()
+}
+
+// Available levels.
+const (
+	LevelDebug = Level(slog.LevelDebug)
+	LevelInfo  = Level(slog.LevelInfo)
+	LevelWarn  = Level(slog.LevelWarn)
+	LevelError = Level(slog.LevelError)
+)
+
 // Logger is a minimal, tightly coupled logger providing visibility into an
 // [Engine]'s progress.
 type Logger struct {
-	mu  sync.Mutex
-	out io.Writer
+	mu          sync.Mutex
+	out         io.Writer
+	diagnostics map[string][]DiagnosticRecord // workflow path -> records
 
 	fancy         bool
 	stepWritten   atomic.Bool
@@ -413,7 +438,6 @@ type Logger struct {
 
 // StartSection logs a header line marking a new phase.
 func (l *Logger) StartSection(msg string, args ...any) {
-	l.writeln("")
 	l.writeln(boldf(msg, args...))
 }
 
@@ -425,20 +449,70 @@ func (l *Logger) StepInfo(workflow Workflow, step *Step, msg string, args ...any
 // StepError logs an error-level message for a specific [Workflow] and [Step].
 func (l *Logger) StepError(workflow Workflow, step *Step, err error) {
 	l.stepLog(slog.LevelError, workflow, step, err.Error())
+	l.addDiagnostic(LevelError, workflow, step, err.Error())
 }
 
 // FinishSection logs a footer line marking the end of a phase.
 func (l *Logger) FinishSection(msg string, args ...any) {
 	l.writeln(boldf(msg, args...))
 	l.stepWritten.Store(false)
+	l.writeln("")
 }
 
-func (l *Logger) stepLog(_ slog.Level, workflow Workflow, step *Step, msg string, args ...any) {
+func (l *Logger) stepLog(level slog.Level, workflow Workflow, step *Step, msg string, args ...any) {
 	prefixTmpl := fmt.Sprintf("file=%%-%ds action=%%-%ds → ", l.workflowWidth, l.stepWidth)
 	prefix := fmt.Sprintf(prefixTmpl, filepath.Base(workflow.FilePath), step.Action.Name)
 	msg = fmt.Sprintf(prefix+msg, args...)
+	if level == slog.LevelError {
+		msg = red(msg)
+	}
 	l.writeln(msg)
 	l.stepWritten.Store(true)
+}
+func (l *Logger) addDiagnostic(level Level, w Workflow, s *Step, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.diagnostics == nil {
+		l.diagnostics = make(map[string][]DiagnosticRecord)
+	}
+	key := w.FilePath
+	l.diagnostics[key] = append(l.diagnostics[key], DiagnosticRecord{
+		Level: level,
+		Step:  *s,
+		Msg:   msg,
+	})
+}
+
+func (l *Logger) ShowDiagnistics() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if len(l.diagnostics) == 0 {
+		return
+	}
+
+	msgPrefixTmpl := fmt.Sprintf("%%5s %%-%ds → ", l.stepWidth)
+
+	fmt.Fprintln(l.out, bold("diagnostics"))
+
+	workflowKeys := slices.Sorted(maps.Keys(l.diagnostics))
+	for _, workflow := range workflowKeys {
+		fmt.Fprintln(l.out, " ", bold(workflow))
+		for _, rec := range l.diagnostics[workflow] {
+			msgPrefix := fmt.Sprintf(msgPrefixTmpl, rec.Level, rec.Step.Action.Name)
+			msg := fmt.Sprintf("    %s%s", msgPrefix, rec.Msg)
+
+			switch rec.Level {
+			case LevelWarn:
+				msg = yellow(msg)
+			case LevelError:
+				msg = red(msg)
+			}
+
+			fmt.Fprintln(l.out, msg)
+		}
+	}
+	fmt.Fprintln(l.out)
 }
 
 func (l *Logger) writeln(msg string) {
@@ -457,4 +531,10 @@ func (l *Logger) precomputeColumnWidths(root Root) {
 			l.stepWidth = max(l.stepWidth, len(step.Action.Name))
 		}
 	}
+}
+
+type DiagnosticRecord struct {
+	Level Level
+	Step  Step
+	Msg   string
 }

--- a/github.go
+++ b/github.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"iter"
 	"log/slog"
 	"net/http"
@@ -138,7 +139,8 @@ func (c *GitHubClient) doREST(ctx context.Context, method string, url string, ta
 		case 403:
 			return errors.New("access denied")
 		default:
-			return fmt.Errorf("http error: %s", resp.Status)
+			body, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("http error: %s: %s", resp.Status, string(body))
 		}
 	}
 	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {

--- a/testdata/golden/cmd-list.stdout
+++ b/testdata/golden/cmd-list.stdout
@@ -1,69 +1,73 @@
 
-in workflow 01-already-pinned.yaml
-  action mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 has available versions:
+workflow 01-already-pinned.yaml
+  action mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 versions:
     current: 75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     ✓ already using latest version
-  action mccutchen/ghavm-test-repo@e31a34957100bbd9e4ef4119114615b944a3a5b1 has available versions:
+  action mccutchen/ghavm-test-repo@e31a34957100bbd9e4ef4119114615b944a3a5b1 versions:
     current: e31a34957100bbd9e4ef4119114615b944a3a5b1 @ v4.1.1
     compat:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@e31a34957100bbd9e4ef4119114615b944a3a5b1 has available versions:
+  action mccutchen/ghavm-test-repo@e31a34957100bbd9e4ef4119114615b944a3a5b1 versions:
     current: e31a34957100bbd9e4ef4119114615b944a3a5b1 @ v4.1.1
     compat:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@4ac411f47580d9304c9410d997568adbe7651f35 has available versions:
+  action mccutchen/ghavm-test-repo@4ac411f47580d9304c9410d997568adbe7651f35 versions:
     current: 4ac411f47580d9304c9410d997568adbe7651f35 @ v1.1.2
     compat:  887cee452dfcd94ce9ab022cb7b0263940c41e4a @ v1.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
 
-in workflow 02-semver-unpinned.yaml
-  action mccutchen/ghavm-test-repo@v4.2.3 has available versions:
+workflow 02-semver-unpinned.yaml
+  action mccutchen/ghavm-test-repo@v4.2.3 versions:
     current: 75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     ✓ already using latest version
-  action mccutchen/ghavm-test-repo@v4 has available versions:
+  action mccutchen/ghavm-test-repo@v4 versions:
     current: 75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     ✓ already using latest version
-  action mccutchen/ghavm-test-repo@v2 has available versions:
+  action mccutchen/ghavm-test-repo@v2 versions:
     current: fd663af41ca3473570136ee6ff8fb80adfae3565 @ v2.2.3
     compat:  ✓ already using latest compat version
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@v3.2.1 has available versions:
+  action mccutchen/ghavm-test-repo@v3.2.1 versions:
     current: 3e81467f76a58c3d7a2d6ba3801efd2f81d744e7 @ v3.2.1
     compat:  3c867123aa53f955575f72c821d4323b632fd96f @ v3.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@v3.2.1 has available versions:
+  action mccutchen/ghavm-test-repo@v3.2.1 versions:
     current: 3e81467f76a58c3d7a2d6ba3801efd2f81d744e7 @ v3.2.1
     compat:  3c867123aa53f955575f72c821d4323b632fd96f @ v3.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@v4.1.2 has available versions:
+  action mccutchen/ghavm-test-repo@v4.1.2 versions:
     current: a1c009077548b2c32b31ac1f95899ada0a4de129 @ v4.1.2
     compat:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
 
-in workflow 03-edge-cases.yml
-  action mccutchen/ghavm-test-repo@c464581d has available versions:
+workflow 03-edge-cases.yml
+  action mccutchen/ghavm-test-repo@c464581d versions:
     current: c464581d8e7a16dab2029f7a34c81fe75f03a49d @ v2.2.2
     compat:  fd663af41ca3473570136ee6ff8fb80adfae3565 @ v2.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 has available versions:
+  action mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 versions:
     current: 75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
     ✓ already using latest version
-  action mccutchen/ghavm-test-repo@c09a940bc73914e8d734930e72cf8816613b1b4f has available versions:
+  action mccutchen/ghavm-test-repo@c09a940bc73914e8d734930e72cf8816613b1b4f versions:
     current: c09a940bc73914e8d734930e72cf8816613b1b4f @ v0.0.1
     compat:  84869029ae0e95416be1613c248447cb020e8d93 @ v0.2.3
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@develop has available versions:
+  action mccutchen/ghavm-test-nonexistent-repo@v1 versions:
+    (could not resolve action versions, unable to pin or upgrade)
+  action mccutchen/ghavm-test-repo@develop versions:
     current: 46852083c58587e34fd537e1391e5408779f1762
     (no upgrade versions found)
-  action mccutchen/ghavm-test-repo@feature/new_feature-01 has available versions:
+  action mccutchen/ghavm-test-repo@feature/new_feature-01 versions:
     current: fd663af41ca3473570136ee6ff8fb80adfae3565 @ v2.2.3
     compat:  ✓ already using latest compat version
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@v3.2.3-annotated has available versions:
+  action mccutchen/ghavm-test-repo@v99.99.99 versions:
+    (could not resolve action versions, unable to pin or upgrade)
+  action mccutchen/ghavm-test-repo@v3.2.3-annotated versions:
     current: 3c867123aa53f955575f72c821d4323b632fd96f @ v3.2.3
     compat:  ✓ already using latest compat version
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3
-  action mccutchen/ghavm-test-repo@3c867123aa53f955575f72c821d4323b632fd96f has available versions:
+  action mccutchen/ghavm-test-repo@3c867123aa53f955575f72c821d4323b632fd96f versions:
     current: 3c867123aa53f955575f72c821d4323b632fd96f @ v3.2.3
     compat:  ✓ already using latest compat version
     latest:  75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 @ v4.2.3

--- a/testdata/golden/cmd-pin.outdir/03-edge-cases.yml
+++ b/testdata/golden/cmd-pin.outdir/03-edge-cases.yml
@@ -21,11 +21,17 @@ jobs:
       - name: trailing data in comment is dropped when updating
         uses: mccutchen/ghavm-test-repo@c09a940bc73914e8d734930e72cf8816613b1b4f # v0.0.1
 
+      - name: repo doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-nonexistent-repo@v1
+
       - name: branch name that does not correspond to any release
         uses: mccutchen/ghavm-test-repo@46852083c58587e34fd537e1391e5408779f1762 # ref:develop
 
       - name: symbolic name that happens to resolve to semver release
         uses: mccutchen/ghavm-test-repo@fd663af41ca3473570136ee6ff8fb80adfae3565 # v2.2.3
+
+      - name: ref doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-repo@v99.99.99
 
       - name: annotated tag requires special handling
         uses: mccutchen/ghavm-test-repo@3c867123aa53f955575f72c821d4323b632fd96f # v3.2.3

--- a/testdata/golden/cmd-upgrade-compat.outdir/03-edge-cases.yml
+++ b/testdata/golden/cmd-upgrade-compat.outdir/03-edge-cases.yml
@@ -21,11 +21,17 @@ jobs:
       - name: trailing data in comment is dropped when updating
         uses: mccutchen/ghavm-test-repo@84869029ae0e95416be1613c248447cb020e8d93 # v0.2.3
 
+      - name: repo doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-nonexistent-repo@v1
+
       - name: branch name that does not correspond to any release
         uses: mccutchen/ghavm-test-repo@46852083c58587e34fd537e1391e5408779f1762 # ref:develop
 
       - name: symbolic name that happens to resolve to semver release
         uses: mccutchen/ghavm-test-repo@fd663af41ca3473570136ee6ff8fb80adfae3565 # v2.2.3
+
+      - name: ref doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-repo@v99.99.99
 
       - name: annotated tag requires special handling
         uses: mccutchen/ghavm-test-repo@3c867123aa53f955575f72c821d4323b632fd96f # v3.2.3

--- a/testdata/golden/cmd-upgrade-default.outdir/03-edge-cases.yml
+++ b/testdata/golden/cmd-upgrade-default.outdir/03-edge-cases.yml
@@ -21,11 +21,17 @@ jobs:
       - name: trailing data in comment is dropped when updating
         uses: mccutchen/ghavm-test-repo@84869029ae0e95416be1613c248447cb020e8d93 # v0.2.3
 
+      - name: repo doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-nonexistent-repo@v1
+
       - name: branch name that does not correspond to any release
         uses: mccutchen/ghavm-test-repo@46852083c58587e34fd537e1391e5408779f1762 # ref:develop
 
       - name: symbolic name that happens to resolve to semver release
         uses: mccutchen/ghavm-test-repo@fd663af41ca3473570136ee6ff8fb80adfae3565 # v2.2.3
+
+      - name: ref doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-repo@v99.99.99
 
       - name: annotated tag requires special handling
         uses: mccutchen/ghavm-test-repo@3c867123aa53f955575f72c821d4323b632fd96f # v3.2.3

--- a/testdata/golden/cmd-upgrade-latest.outdir/03-edge-cases.yml
+++ b/testdata/golden/cmd-upgrade-latest.outdir/03-edge-cases.yml
@@ -21,11 +21,17 @@ jobs:
       - name: trailing data in comment is dropped when updating
         uses: mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 # v4.2.3
 
+      - name: repo doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-nonexistent-repo@v1
+
       - name: branch name that does not correspond to any release
         uses: mccutchen/ghavm-test-repo@46852083c58587e34fd537e1391e5408779f1762 # ref:develop
 
       - name: symbolic name that happens to resolve to semver release
         uses: mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 # v4.2.3
+
+      - name: ref doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-repo@v99.99.99
 
       - name: annotated tag requires special handling
         uses: mccutchen/ghavm-test-repo@75e35fafbce9720ebaf2c4e8bf1c4950260c35c3 # v4.2.3

--- a/testdata/workflows/03-edge-cases.yml
+++ b/testdata/workflows/03-edge-cases.yml
@@ -21,11 +21,17 @@ jobs:
       - name: trailing data in comment is dropped when updating
         uses: mccutchen/ghavm-test-repo@c09a940bc73914e8d734930e72cf8816613b1b4f # v0.0.1: extra context will be dropped
 
+      - name: repo doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-nonexistent-repo@v1
+
       - name: branch name that does not correspond to any release
         uses: mccutchen/ghavm-test-repo@develop
 
       - name: symbolic name that happens to resolve to semver release
         uses: mccutchen/ghavm-test-repo@feature/new_feature-01
+
+      - name: ref doesn't exist but that should not prevent updating subsequent steps
+        uses: mccutchen/ghavm-test-repo@v99.99.99
 
       - name: annotated tag requires special handling
         uses: mccutchen/ghavm-test-repo@v3.2.3-annotated


### PR DESCRIPTION
Before this change, the engine would abort the entire process if we failed to resolve a single ref (or encountered any other errors):

<img width="1590" alt="Screenshot 2025-05-31 at 8 45 57 AM" src="https://github.com/user-attachments/assets/95f39036-61ab-4a52-add6-009160943e12" />

Now we capture errors encountered and report them at the end, but proceed to do as much useful work as we can:

<img width="1590" alt="Screenshot 2025-05-31 at 8 46 26 AM" src="https://github.com/user-attachments/assets/c662626f-e84c-41c5-8102-70014821e20a" />
