### PR TITLE
ci: new approach to docker signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: sign images with cosign
+        run: |
+          GIT_TAG=${GITHUB_REF#refs/tags/}
+          DOCKER_TAG=${GIT_TAG#v} # remove 'v' prefix
+
+          DIGEST=$(docker buildx imagetools inspect ghcr.io/mccutchen/ghavm:$DOCKER_TAG | grep "Digest:" | awk '{print $2}')
+
+          images=""
+          images+="ghcr.io/mccutchen/ghavm:$DOCKER_TAG@$DIGEST "
+          images+="ghcr.io/mccutchen/ghavm:latest@$DIGEST "
+          images+="mccutchen/ghavm:$DOCKER_TAG@$DIGEST "
+          images+="mccutchen/ghavm:latest@$DIGEST "
+
+          cosign sign --yes ${images}
+
       - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-checksums: ./dist/checksums.txt

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,7 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MIT"
     goos: linux
     goarch: amd64
+    use: buildx
   - image_templates:
       - "mccutchen/ghavm:{{ .Version }}-arm64"
       - "ghcr.io/mccutchen/ghavm:{{ .Version }}-arm64"
@@ -72,6 +73,8 @@ dockers:
       - "--label=org.opencontainers.image.licenses=MIT"
     goos: linux
     goarch: arm64
+    use: buildx
+    skip_push: true
 
 docker_manifests:
   - name_template: "mccutchen/ghavm:{{ .Version }}"
@@ -90,15 +93,6 @@ docker_manifests:
     image_templates:
       - "ghcr.io/mccutchen/ghavm:{{ .Version }}-amd64"
       - "ghcr.io/mccutchen/ghavm:{{ .Version }}-arm64"
-
-docker_signs:
-  - artifacts: all
-    cmd: cosign
-    args:
-      - "sign"
-      - "--yes"
-      - "${artifact}"
-    output: true
 
 release:
   github:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,8 @@ FROM gcr.io/distroless/base
 #
 COPY ghavm /usr/local/bin/ghavm
 
+# Run with, e.g., --volume $(PWD):/src:rw
+WORKDIR /src
+VOLUME  /src
+
 ENTRYPOINT ["/usr/local/bin/ghavm"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ problem `ghavm` helps solve, and further reading on properly securing GitHub
 Actions workflows.
 
 
+## Installation
+
+- Install [latest release][release] from GitHub
+- Run Docker/OCI image:
+  ```
+  docker run --rm -e GITHUB_TOKEN -v $(PWD):/src ghcr.io/mccutchen/ghavm pin
+  ```
+- Install or run using a local Go toolchain:
+  ```
+  go install github.com/mccutchen/ghavm@latest
+  ```
+  or
+  ```
+  go run github.com/mccutchen/ghavm@latest pin
+  ```
+
+
 ## Getting started
 
 First, you might use `ghavm pin` to **pin your actions to immutable commit
@@ -233,5 +250,6 @@ MIT
 [wiz-sec]: https://www.wiz.io/blog/github-actions-security-guide
 [step-sec]: https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide
 [gg-sec]: https://blog.gitguardian.com/github-actions-security-cheat-sheet/
+[release]: https://github.com/mccutchen/ghavm/releases/latest
 [mheap/pin-github-action]: https://github.com/mheap/pin-github-action
 [dependabot]: https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#github-actions


### PR DESCRIPTION
A quick follow-up to https://github.com/mccutchen/ghavm/pull/27

---

The built-in goreleaser `docker_signs` approach to signing images and manifests ends up pushing weird "cosign signature artifact" tags(?) like `sha256-b8671085f61c1f89fcfd4a56e2b0a500e5a8aa0a18066d0f22be552f93f8ae69.sig` to remote registries, and because it pushes those _after_ it pushes the images themselves, those weird tags show up at the top of each registry UI:

<img width="972" height="479" alt="image" src="https://github.com/user-attachments/assets/02f21e95-010c-4af7-835f-4077ee774cdc" />

Let's try using cosign's built-in support for "keyless" signing via the GitHub Actions OIDC mechanism.

---

We also make a couple of other small tweaks:
- Fix workdir in dockerfile so that it is actually useful
- Update README