### PR TITLE
ci: fine-tune built docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,12 +3,12 @@ name: release
 "on":
   release:
     types: [created]
-  # we do not build and push images for every commit, only for tagged releases.
+  # we do not trigger builds for every commit, only for tagged releases.
   # uncomment this to enablle building for pull requests, to debug this
   # workflow.
   #
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 permissions:
   contents: write
@@ -24,12 +24,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      # deps
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - uses: anchore/sbom-action/download-syft@v0.20.2
 
-      # first, run goreleaser to build multi-arch and multi-platform release
-      # artifacts.
+      # log into docker registries
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # run goreleaser to build multi-arch and multi-platform release binaries
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           distribution: goreleaser
@@ -42,20 +54,12 @@ jobs:
           with:
             subject-checksums: ./dist/checksums.txt
 
-      # after binaries are built, we build and sign docker images.
+      # after binaries are built, we build and sign docker images
       #
       # the docker build depends on the binaries built by goreleaser in the
       # dist/ghavm_linux_*/ build output directories.
-      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean up dist directory
+        run: rm -rf dist/*.tar.gz dist/*.sbom.json dist/ghavm_darwin_*
 
       - uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         id: docker-meta
@@ -93,7 +97,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: sign images with cosign
+      - name: Sign images with cosign
         env:
           DIGEST: ${{ steps.docker-build.outputs.digest }}
           TAGS: ${{ steps.docker-meta.outputs.tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,8 +51,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-          with:
-            subject-checksums: ./dist/checksums.txt
+        with:
+          subject-checksums: ./dist/checksums.txt
 
       # after binaries are built, we build and sign docker images
       #

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
 
       # build and sign docker images, using the pre-built release artifacts
       # goreleaser placed in the dist/ghavm_linux_*/ directories.
-      - name: Clean up dist directory
+      - name: "Run script: clean up dist directory"
         run: rm -rf dist/*.tar.gz dist/*.sbom.json dist/ghavm_darwin_*
 
       - uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -104,7 +104,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Sign images with cosign
+      - name: "Run script: sign images with cosign"
         env:
           DIGEST: ${{ steps.docker-build.outputs.digest }}
           TAGS: ${{ steps.docker-meta.outputs.tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,9 @@ jobs:
 
       # deps
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 'stable'
+          cache: true
       - uses: anchore/sbom-action/download-syft@v0.20.2
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
@@ -42,7 +45,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # run goreleaser to build multi-arch and multi-platform release binaries
+      # run goreleaser to build multi-arch and multi-platform release
+      # artifacts.
+      #
+      # note: artifacts will only be uploaded to a GitHub release when
+      # triggered by a new release event.
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           distribution: goreleaser
@@ -55,10 +62,8 @@ jobs:
         with:
           subject-checksums: ./dist/checksums.txt
 
-      # after binaries are built, we build and sign docker images
-      #
-      # the docker build depends on the binaries built by goreleaser in the
-      # dist/ghavm_linux_*/ build output directories.
+      # build and sign docker images, using the pre-built release artifacts
+      # goreleaser placed in the dist/ghavm_linux_*/ directories.
       - name: Clean up dist directory
         run: rm -rf dist/*.tar.gz dist/*.sbom.json dist/ghavm_darwin_*
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,8 @@ name: release
   # uncomment this to enablle building for pull requests, to debug this
   # workflow.
   #
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,8 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Sign images with cosign
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,8 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: docker-build
         with:
-          context: dist
+          file: ./Dockerfile
+          context: ./dist
           platforms: linux/amd64,linux/arm64
           push: true
           sbom: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,14 @@
 name: release
 
-on:
+"on":
   release:
     types: [created]
+  # we do not build and push images for every commit, only for tagged releases.
+  # uncomment this to enablle building for pull requests, to debug this
+  # workflow.
+  #
+  # pull_request:
+  #   branches: [main]
 
 permissions:
   contents: write
@@ -22,6 +28,24 @@ jobs:
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - uses: anchore/sbom-action/download-syft@v0.20.2
 
+      # first, run goreleaser to build multi-arch and multi-platform release
+      # artifacts.
+      - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean ${{ github.event_name == 'pull_request' && ' --snapshot' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+          with:
+            subject-checksums: ./dist/checksums.txt
+
+      # after binaries are built, we build and sign docker images.
+      #
+      # the docker build depends on the binaries built by goreleaser in the
+      # dist/ghavm_linux_*/ build output directories.
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -33,29 +57,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
-        with:
-          distribution: goreleaser
-          version: '~> v2'
-          args: release --clean
+      - uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        id: docker-meta
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # https://docs.docker.com/build/ci/github-actions/annotations/#configure-annotation-level
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
+          tags: |
+            # For releases, use the standard tags and special "latest" tag
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+            # For pull requests, use the commit SHA
+            #
+            # Note that this is disabled by default, but can be enabled for
+            # debugging purposes by uncommenting the pull_request trigger at
+            # top of the workflow.
+            type=sha,format=short,enable=${{ github.event_name == 'pull_request' }}
+
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker-build
+        with:
+          context: dist
+          platforms: linux/amd64,linux/arm64
+          push: true
+          sbom: true
+          provenance: mode=max
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
+          annotations: ${{ steps.docker-meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: sign images with cosign
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
+          TAGS: ${{ steps.docker-meta.outputs.tags }}
         run: |
-          GIT_TAG=${GITHUB_REF#refs/tags/}
-          DOCKER_TAG=${GIT_TAG#v} # remove 'v' prefix
-
-          DIGEST=$(docker buildx imagetools inspect ghcr.io/mccutchen/ghavm:$DOCKER_TAG | grep "Digest:" | awk '{print $2}')
-
           images=""
-          images+="ghcr.io/mccutchen/ghavm:$DOCKER_TAG@$DIGEST "
-          images+="ghcr.io/mccutchen/ghavm:latest@$DIGEST "
-          images+="mccutchen/ghavm:$DOCKER_TAG@$DIGEST "
-          images+="mccutchen/ghavm:latest@$DIGEST "
-
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
           cosign sign --yes ${images}
-
-      - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-        with:
-          subject-checksums: ./dist/checksums.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,8 +94,6 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Sign images with cosign
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,9 @@ jobs:
 
       # deps
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - uses: anchore/sbom-action/download-syft@v0.20.2
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       # log into docker registries
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,8 @@ name: release
   # uncomment this to enablle building for pull requests, to debug this
   # workflow.
   #
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,60 +39,6 @@ checksum:
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
-dockers:
-  - image_templates:
-      - "mccutchen/ghavm:{{ .Version }}-amd64"
-      - "ghcr.io/mccutchen/ghavm:{{ .Version }}-amd64"
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=GitHub Actions Version Manager"
-      - "--label=org.opencontainers.image.url=https://github.com/mccutchen/ghavm"
-      - "--label=org.opencontainers.image.source=https://github.com/mccutchen/ghavm"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-    goos: linux
-    goarch: amd64
-    use: buildx
-  - image_templates:
-      - "mccutchen/ghavm:{{ .Version }}-arm64"
-      - "ghcr.io/mccutchen/ghavm:{{ .Version }}-arm64"
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=GitHub Actions Version Manager"
-      - "--label=org.opencontainers.image.url=https://github.com/mccutchen/ghavm"
-      - "--label=org.opencontainers.image.source=https://github.com/mccutchen/ghavm"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-    goos: linux
-    goarch: arm64
-    use: buildx
-
-docker_manifests:
-  - name_template: "mccutchen/ghavm:{{ .Version }}"
-    image_templates:
-      - "mccutchen/ghavm:{{ .Version }}-amd64"
-      - "mccutchen/ghavm:{{ .Version }}-arm64"
-  - name_template: "mccutchen/ghavm:latest"
-    image_templates:
-      - "mccutchen/ghavm:{{ .Version }}-amd64"
-      - "mccutchen/ghavm:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/mccutchen/ghavm:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/mccutchen/ghavm:{{ .Version }}-amd64"
-      - "ghcr.io/mccutchen/ghavm:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/mccutchen/ghavm:latest"
-    image_templates:
-      - "ghcr.io/mccutchen/ghavm:{{ .Version }}-amd64"
-      - "ghcr.io/mccutchen/ghavm:{{ .Version }}-arm64"
-
 release:
   github:
     owner: mccutchen

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM gcr.io/distroless/base
 # - .github/workflows/release.yml
 # - Makefile (make release-dry-run)
 ARG TARGETARCH
-COPY dist/ghavm_linux_${TARGETARCH}_*/ghavm /usr/local/bin/ghavm
+COPY ghavm_linux_${TARGETARCH}_*/ghavm /usr/local/bin/ghavm
 
 # Run with, e.g., --volume $(PWD):/src:rw
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM gcr.io/distroless/base
 
-# This Dockerfile is used by goreleaser to build multi-arch images to be
-# published to public registries for every release.
+# This Dockerfile is by the release.yaml GH Actions workflow to build
+# multi-arch images to be published to public registries for every release.
 #
-# The binaries are first cross-compiled on the host machine (generally a GH
-# Actions worker) and copied into the image directly.
+# The binaries are first cross-compiled on the host machine by goreleaser and
+# copied into the image directly.
 #
 # It is not meant to be built manually.
 #
@@ -12,8 +12,8 @@ FROM gcr.io/distroless/base
 # - .goreleaser.yaml
 # - .github/workflows/release.yml
 # - Makefile (make release-dry-run)
-#
-COPY ghavm /usr/local/bin/ghavm
+ARG TARGETARCH
+COPY dist/ghavm_linux_${TARGETARCH}_*/ghavm /usr/local/bin/ghavm
 
 # Run with, e.g., --volume $(PWD):/src:rw
 WORKDIR /src


### PR DESCRIPTION
Here we stop configuring goreleaser to build and push docker images, because that was resulting in a confusing proliferation of tags (both individual `vX.Y.Z-{arch}` tags and `vX.Y.Z` multi-arch manifests).

Instead, we have goreleaser build multi-platform, multi-arch release artifacts and then manually build and sign docker images in a follow-up step, using the off-the-shelf docker/build-push-action to properly handle multi-arch manifests with sbom and attestation.