### PR TITLE
ci: add custom golangci-lint configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  default: standard
+
+  enable:
+  - bodyclose
+  - contextcheck
+  - copyloopvar
+  - gosec
+  - paralleltest
+  - revive
+
+formatters:
+  enable:
+    - gofumpt

--- a/internal/ghavm/cli.go
+++ b/internal/ghavm/cli.go
@@ -1,3 +1,4 @@
+// Package ghavm implements GitHub Actions version management.
 package ghavm
 
 import (
@@ -14,11 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RunApp runs a cobra CLI app with the given args.
 func RunApp(app *cobra.Command, args []string) error {
 	app.SetArgs(args)
 	return app.Execute()
 }
 
+// NewApp creates the CLI for ghavm.
 func NewApp(stdin io.Reader, stdout io.Writer, stderr io.Writer, getenv func(string) string, versionInfo string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "ghavm",
@@ -27,7 +30,7 @@ func NewApp(stdin io.Reader, stdout io.Writer, stderr io.Writer, getenv func(str
 		SilenceUsage: true,
 
 		// Short-circuit handling of --version flag
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if versionFlag, _ := cmd.Flags().GetBool("version"); versionFlag {
 				fprintln(cmd.OutOrStdout(), versionInfo)
 				return nil

--- a/internal/ghavm/cli_test.go
+++ b/internal/ghavm/cli_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestCLI(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		args       []string
 		env        map[string]string
@@ -81,6 +83,8 @@ func TestCLI(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			// use fake env for testing CLI errors to ensure we don't
 			// accidentally grab a real GITHUB_TOKEN or other env vars.
 			getenv := func(key string) string {

--- a/internal/ghavm/cli_test.go
+++ b/internal/ghavm/cli_test.go
@@ -80,7 +80,6 @@ func TestCLI(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// use fake env for testing CLI errors to ensure we don't
 			// accidentally grab a real GITHUB_TOKEN or other env vars.

--- a/internal/ghavm/engine_test.go
+++ b/internal/ghavm/engine_test.go
@@ -202,6 +202,8 @@ func TestNewEngine(t *testing.T) {
 }
 
 func TestTruncateToDisplayWidth(t *testing.T) {
+	t.Parallel()
+
 	tests := map[string]struct {
 		input    string
 		width    int
@@ -271,6 +273,7 @@ func TestTruncateToDisplayWidth(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			result := truncateToDisplayWidth(tc.input, tc.width)
 			assert.Equal(t, result, tc.expected, "incorrect result")
 		})

--- a/internal/ghavm/engine_test.go
+++ b/internal/ghavm/engine_test.go
@@ -69,7 +69,7 @@ func TestIntegrationTests(t *testing.T) {
 			assert.NilError(t, app.Execute())
 
 			goldenPath := filepath.Join("testdata", "golden", fmt.Sprintf("cmd-list%s.stdout", pathSuffix))
-			want, err := os.ReadFile(goldenPath)
+			want, err := os.ReadFile(goldenPath) // #nosec G304
 			assert.NilError(t, err)
 
 			if stdout.String() != string(want) {
@@ -123,7 +123,6 @@ func TestIntegrationTests(t *testing.T) {
 	}
 
 	for _, goldenDirName := range goldenDirs {
-		goldenDirName := goldenDirName
 		t.Run("golden/"+goldenDirName, func(t *testing.T) {
 			t.Parallel()
 
@@ -271,7 +270,6 @@ func TestTruncateToDisplayWidth(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			result := truncateToDisplayWidth(tc.input, tc.width)
 			assert.Equal(t, result, tc.expected, "incorrect result")

--- a/internal/ghavm/github_test.go
+++ b/internal/ghavm/github_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	client := NewGitHubClient("token", nil)
 	if client.httpClient == nil {
 		t.Error("Expected HTTP client to be initialized")
@@ -722,6 +723,7 @@ func TestIsUpgradeCandidate(t *testing.T) {
 
 	for _, tc := range upgradeCases {
 		t.Run(fmt.Sprintf("isUpgradeCandidate(%s,%s)", tc.current, tc.candidate), func(t *testing.T) {
+			t.Parallel()
 			result := isUpgradeCandidate(tc.current, tc.candidate)
 			assert.Equal(t, result, tc.expected, "is upgrade candidate?")
 		})
@@ -753,6 +755,7 @@ func TestChooseNewestRelease(t *testing.T) {
 	}
 	for name, tc := range releaseCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			result := chooseNewestRelease(tc.a, tc.b)
 			assert.Equal(t, result, tc.expected, "choose newest release")
 		})

--- a/internal/ghavm/github_test.go
+++ b/internal/ghavm/github_test.go
@@ -322,7 +322,6 @@ func TestGetUpgradeCandidates(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			client := newTestClient(t, tc.gqlEndpoints, nil)
@@ -518,7 +517,6 @@ func TestGetVersionTagsForHash(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			client := newTestClient(t, tc.gqlEndpoints, nil)
@@ -627,7 +625,6 @@ func TestGetCommitHashForRef(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			client := newTestClient(t, nil, tc.restEndpoints)
@@ -674,7 +671,6 @@ func TestValidateAuth(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			client := newTestClient(t, nil, tc.restEndpoints)
@@ -725,7 +721,6 @@ func TestIsUpgradeCandidate(t *testing.T) {
 	}
 
 	for _, tc := range upgradeCases {
-		tc := tc
 		t.Run(fmt.Sprintf("isUpgradeCandidate(%s,%s)", tc.current, tc.candidate), func(t *testing.T) {
 			result := isUpgradeCandidate(tc.current, tc.candidate)
 			assert.Equal(t, result, tc.expected, "is upgrade candidate?")
@@ -757,7 +752,6 @@ func TestChooseNewestRelease(t *testing.T) {
 		},
 	}
 	for name, tc := range releaseCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			result := chooseNewestRelease(tc.a, tc.b)
 			assert.Equal(t, result, tc.expected, "choose newest release")
@@ -776,7 +770,7 @@ func TestChooseNewestRelease(t *testing.T) {
 // See [graphqlSig] and [restSig] for details.
 func newTestClient(t testing.TB, graphqlEndpoints map[string]httpResponse, restEndpoints map[string]httpResponse) *GitHubClient {
 	t.Helper()
-	const fakeAuthToken = "fake-auth-token"
+	const fakeAuthToken = "fake-auth-token" // #nosec G101
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Header.Get("Authorization"), "Bearer "+fakeAuthToken, "incorrect Authorization header")
 		switch r.URL.Path {

--- a/internal/ghavm/scanner.go
+++ b/internal/ghavm/scanner.go
@@ -73,7 +73,7 @@ func ScanWorkflows(filePaths []string, opts scanOpts) (Root, error) {
 }
 
 func scanFile(filePath string, opts scanOpts) (Workflow, error) {
-	f, err := os.Open(filePath)
+	f, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
 		return Workflow{}, fmt.Errorf("scanner: failed to open file %s: %w", filePath, err)
 	}

--- a/internal/ghavm/scanner_test.go
+++ b/internal/ghavm/scanner_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestMaybeParseAction(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		line string
 		want Action
@@ -132,6 +134,7 @@ func TestMaybeParseAction(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.line, func(t *testing.T) {
+			t.Parallel()
 			got := maybeParseAction(tc.line)
 			assert.Equal(t, got, tc.want, "incorrect result")
 		})
@@ -139,6 +142,8 @@ func TestMaybeParseAction(t *testing.T) {
 }
 
 func TestScanFileFiltering(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		opts     scanOpts
 		expected []string
@@ -191,6 +196,8 @@ func TestScanFileFiltering(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			workflow, err := scanFile(path.Join("testdata", "example.yaml"), tc.opts)
 			assert.NilError(t, err)
 
@@ -205,6 +212,8 @@ func TestScanFileFiltering(t *testing.T) {
 }
 
 func TestValidatePattern(t *testing.T) {
+	t.Parallel()
+
 	validCases := []string{
 		"*",
 		"actions/*",
@@ -216,6 +225,7 @@ func TestValidatePattern(t *testing.T) {
 
 	for _, pattern := range validCases {
 		t.Run("valid/"+pattern, func(t *testing.T) {
+			t.Parallel()
 			err := validatePattern(pattern)
 			assert.NilError(t, err)
 		})
@@ -234,6 +244,7 @@ func TestValidatePattern(t *testing.T) {
 
 	for _, tc := range invalidCases {
 		t.Run("invalid/"+tc.pattern, func(t *testing.T) {
+			t.Parallel()
 			err := validatePattern(tc.pattern)
 			if err == nil {
 				t.Fatal("expected error but got nil")
@@ -244,6 +255,8 @@ func TestValidatePattern(t *testing.T) {
 }
 
 func TestActionRepo(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name     string
 		expected string
@@ -258,6 +271,7 @@ func TestActionRepo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			action := Action{Name: tc.name}
 			got := action.Repo()
 			assert.Equal(t, got, tc.expected, "incorrect repo extraction")

--- a/internal/ghavm/scanner_test.go
+++ b/internal/ghavm/scanner_test.go
@@ -131,7 +131,6 @@ func TestMaybeParseAction(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.line, func(t *testing.T) {
 			got := maybeParseAction(tc.line)
 			assert.Equal(t, got, tc.want, "incorrect result")
@@ -191,7 +190,6 @@ func TestScanFileFiltering(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			workflow, err := scanFile(path.Join("testdata", "example.yaml"), tc.opts)
 			assert.NilError(t, err)


### PR DESCRIPTION
This should make golangci-lint match the behavior of the simpler local `make lint` target.