### PR TITLE
build: add Windows support

### DIFF
--- a/internal/ghavm/engine.go
+++ b/internal/ghavm/engine.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 	"unicode/utf8"
 
-	renameio "github.com/google/renameio/v2"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/term"
@@ -218,7 +217,7 @@ func (e *Engine) rewriteWorkflows(ctx context.Context, strategy RewriteStrategy)
 			ctx, "writing pinned file",
 			"file", w.FilePath,
 		)
-		if err := renameio.WriteFile(w.FilePath, []byte(out.String()), 0); err != nil {
+		if err := writeFile(w.FilePath, []byte(out.String()), 0); err != nil {
 			return fmt.Errorf("failed to atomically replace file: %w", err)
 		}
 	}

--- a/internal/ghavm/writefile_unix.go
+++ b/internal/ghavm/writefile_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package ghavm
+
+import (
+	"os"
+
+	renameio "github.com/google/renameio/v2"
+)
+
+// writeFile writes data to a file, creating it if necessary or replacing it
+// atomically otherwise (on macOS/Linux).
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	return renameio.WriteFile(path, data, perm)
+}

--- a/internal/ghavm/writefile_windows.go
+++ b/internal/ghavm/writefile_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package ghavm
+
+import "os"
+
+// writeFile writes data to a file, creating it if necessary. Note that this
+// is not an atomic operation on Windows.
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}


### PR DESCRIPTION
The `github.com/google/renameio/v2` dep [does not support Windows][1]:

> It is not possible to reliably write files atomically on Windows, and
> chmod is not reliably supported by the Go standard library on Windows.
>
> As it is not possible to provide a correct implementation, this
> package does not export any functions on Windows.

This provides an alternate, non-atomic implementation on Windows using plain old `os.WriteFile`.

[1]: https://github.com/google/renameio#windows-support