### PR TITLE
ci: updated release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ name: release
   release:
     types: [published]
   # Uncomment to test the workflow on pull requests
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ name: release
   release:
     types: [published]
   # Uncomment to test the workflow on pull requests
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,35 @@
+# The release workflow is triggered by the creation of a GitHub release and
+# builds cross-platform binaries and multi-arch docker images.
+#
+# For each build artifact, build provenance metadata is generated, signed,
+# attested, etc.
 name: release
-
-concurrency:
-  group: release
-  cancel-in-progress: false
 
 "on":
   release:
-    types: [created]
-  # We do not trigger builds for every commit, only for tagged releases.
-  # Uncomment this to enablle building for pull requests, to debug this
-  # workflow.
-  #
+    types: [published]
+  # Uncomment to test the workflow on pull requests
   # pull_request:
   #   branches: [main]
 
 permissions:
   contents: read
 
+# Serialize release workflows without canceling, on the off chance we need to
+# trigger a quick follow-up release while one is still in progress.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: release
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to publish the GitHub release
-      packages: write # to push to ghcr.io
-      id-token: write # for keyless signing via sigstore/cosign
-      attestations: write # to publish build provenance attestations
+      contents: write      # publish GitHub release and upload release artifacts
+      packages: write      # push OCI images to ghcr.io
+      id-token: write      # request OIDC token for Sigstore signing
+      attestations: write  # publish attestations to GitHub attestation store
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -38,35 +42,26 @@ jobs:
           # caching explicitly disabled in release workflows
           # https://docs.zizmor.sh/audits/#cache-poisoning
           cache: false
-
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      # Only install goreleaser instead of running it; we'll run `make release`
-      # in a subsequent step
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
+          version: '~> v2'
           install-only: true
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Run goreleaser to build multi-arch and multi-platform release
-      # artifacts.
-      #
-      # Note: artifacts will only be uploaded to a GitHub release when
-      # triggered by a new release event, not on pull request events (if
-      # enabled for testing).
-      - name: "Run script: make release"
+      - name: "Run make release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
@@ -82,59 +77,18 @@ jobs:
           # installed by the goreleaser/goreleaser-action step above instead
           # of using the Makefile's default `go run ...` approach because it
           # takes a long time to build goreleaser itself.
-          make "${RELEASE_TARGET}" CMD_GORELEASER="goreleaser"
+          make "${RELEASE_TARGET}" GORELEASER="goreleaser"
 
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: goreleaser-artifacts
+          path: dist/artifacts.json
+
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-checksums: ./dist/checksums.txt
 
-      # Build and sign docker images, using the pre-built release artifacts
-      # goreleaser placed in the dist/ghavm_linux_*/ directories.
-      - name: "Run script: clean up dist dir before docker builds"
-        run: rm -rf dist/*.tar.gz dist/*.sbom.json dist/ghavm_darwin_*
-
-      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        id: docker-meta
-        env:
-          # https://docs.docker.com/build/ci/github-actions/annotations/#configure-annotation-level
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
-          images: |
-            ${{ github.repository }}
-            ghcr.io/${{ github.repository }}
-          tags: |
-            # For releases, use the standard tags and special "latest" tag
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-
-            # For pull requests, use the commit SHA
-            #
-            # Note that this is disabled by default, but can be enabled for
-            # debugging purposes by uncommenting the pull_request trigger at
-            # top of the workflow.
-            type=sha,format=short,enable=${{ github.event_name == 'pull_request' }}
-
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        id: docker-build
-        with:
-          file: ./Dockerfile.release
-          context: ./dist
-          platforms: linux/amd64,linux/arm64
-          push: true
-          sbom: true
-          provenance: mode=max
-          tags: ${{ steps.docker-meta.outputs.tags }}
-          labels: ${{ steps.docker-meta.outputs.labels }}
-          annotations: ${{ steps.docker-meta.outputs.annotations }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: "Run script: make release-sign-images"
-        env:
-          DIGEST: ${{ steps.docker-build.outputs.digest }}
-          TAGS: ${{ steps.docker-meta.outputs.tags }}
-        run:
-          # Note that we override the CMD_COSIGN var to use the binary
-          # installed by the sigstore/cosign-installer step above
-          make release-sign-images CMD_COSIGN="cosign"
+          subject-checksums: ./dist/digests.txt
+          push-to-registry: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,33 +6,25 @@ git:
   tag_sort: "-creatordate"
 
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - main: .
     goos:
-      - linux
       - darwin
+      - linux
+      - windows
     goarch:
       - amd64
       - arm64
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=0
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.buildDate={{.Date}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 # replace per-arch macos binaries with a single universal binary
 universal_binaries:
   - replace: true
-    hooks:
-      post:
-        # FIXME: drop this manual quill invocation if I can ever figure out
-        # why goreleaser's built-in, quill-based notarization support doesn't
-        # work. See the disabled notarize: step below for more context.
-        - cmd: make release-notarize
-          env:
-            - QUILL_AD_HOC={{ .IsSnapshot }}
-            - QUILL_DRY_RUN={{ .IsSnapshot }}
-            - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
 
 source:
   enabled: true
@@ -51,6 +43,10 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     formats:
       - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 
 checksum:
   name_template: 'checksums.txt'
@@ -59,61 +55,67 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 release:
-  github:
-    owner: mccutchen
-    name: ghavm
   draft: false
   prerelease: auto
-  mode: replace
+  mode: keep-existing
 
-# FIXME: this step is disabled in favor of the manual quill invocation in the
-# universal_binaries: step above, until I can figure out why goreleaser's
-# built-in, quill-based notarization support doesn't work.
-#
-# For inscrutable reasons, when using the exact same credentials, goreleaser's
-# notarization attempts fail with a 401 Unauthorized error:
-#
-#     $ make release-dry-run
-#     [... snip ...]
-#       • sign & notarize macOS binaries
-#       • signing                                        binary=dist/ghavm_darwin_all/ghavm
-#       • notarizing and waiting - this might take a while binary=dist/ghavm_darwin_all/ghavm
-#     ⨯ release failed after 3s                          error=notarize: macos: dist/ghavm_darwin_all/ghavm: unable to
-#       start submission: http status="401 Unauthorized":
-#       body="Unauthenticated\n\nRequest ID: 4LBNFD32YYRMV2263S4YLLG2ZE.0.0\n"h
-#
-# Compare that to
-#
-#     $ make release
-#     $ go run github.com/anchore/quill/cmd/quill@latest sign-and-notarize dist/ghavm_darwin_all/ghavm
-#
-# which will successfully notarize the universal binary that was just built.
-#
-# (Look at the .Env references in the config below for the env vars needed for
-# both of the example commands above.)
-#
-# We could simplify our GitHub Actions release.yaml workflow if goreleaser
-# could handle this directly, which would yield more useful/obvious output and
-# let us drop the custom install-quill step we currently use.
-#
-# It would be a lot nicer if goreleaser could handle this directly, because it
-# would let us simplify our GH Actions release workflow (drop manual quill
-# installation) and improve goreleaser output (dedicated top level notary
-# stage instead of hiding it an easy-to-miss post build hook).
-#
-# See goreleaser's docs for this configuration:
-# https://goreleaser.com/customization/notarize/#cross-platform
+dockers_v2:
+  - images:
+      - index.docker.io/mccutchen/ghavm
+      - ghcr.io/mccutchen/ghavm
+    tags:
+      - "{{.Version}}"
+      - '{{ if not .Prerelease }}{{.Major}}.{{.Minor}}{{ end }}'
+      - '{{ if not .Prerelease }}latest{{ end }}'
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: Dockerfile.release
+    sbom: true
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.url: "{{.GitURL}}"
+      org.opencontainers.image.title: "{{.ProjectName}}"
+      org.opencontainers.image.licenses: MIT
+    annotations:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.url: "{{.GitURL}}"
+      org.opencontainers.image.title: "{{.ProjectName}}"
+      org.opencontainers.image.licenses: MIT
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - sign
+      - --yes
+      - "${artifact}@${digest}"
+    # '' is for images built by dockers_v2, per the docs:
+    # https://goreleaser.com/customization/sign/docker_sign/
+    artifacts: ''
+
 notarize:
   macos:
-    - enabled: false
-
+    - enabled: '{{ isEnvSet "QUILL_SIGN_P12" }}'
       sign:
         certificate: "{{.Env.QUILL_SIGN_P12}}"
         password: "{{.Env.QUILL_SIGN_PASSWORD}}"
-
       notarize:
         issuer_id: "{{.Env.QUILL_NOTARY_ISSUER}}"
         key_id: "{{.Env.QUILL_NOTARY_KEY_ID}}"
         key: "{{.Env.QUILL_NOTARY_KEY}}"
         wait: true
-        timeout: 60m
+        # Apple rejects JWTs with ttl > 20m, quill sets token lifetime to
+        # this timeout + 2m.
+        timeout: 18m
+
+changelog:
+  disable: true
+
+announce:
+  skip: true

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,46 @@
+# Built binaries will be placed here
+DIST_PATH  	  ?= dist
+
 # Default flags used by the test, testci, testcover targets
-COVERAGE_PATH ?= coverage.out
+COVERAGE_PATH ?= coverage.txt
 COVERAGE_ARGS ?= -covermode=atomic -coverprofile=$(COVERAGE_PATH)
-TEST_ARGS     ?= -race -count=1 -timeout=60s
-DOCS_PORT     ?= :8080
+TEST_ARGS     ?= -race
 
 # 3rd party tools
-CMD_COSIGN      := go run github.com/sigstore/cosign/cmd/cosign@v2.5.3
-CMD_GOFUMPT     := go run mvdan.cc/gofumpt@v0.8.0
-CMD_GORELEASER  := go run github.com/goreleaser/goreleaser/v2@v2.11.0
-CMD_QUILL       := go run github.com/anchore/quill/cmd/quill@v0.5.1
-CMD_REVIVE      := go run github.com/mgechev/revive@v1.9.0
-CMD_STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2025.1.1
-
-# Where built assets will be placed
-OUT_DIR  ?= out
-DIST_DIR ?= dist
+GOFUMPT     := go run mvdan.cc/gofumpt@v0.9.2
+GORELEASER  := go run github.com/goreleaser/goreleaser/v2@v2.15.2
+REFLEX      := go run github.com/cespare/reflex@v0.3.2
+REVIVE      := go run github.com/mgechev/revive@v1.15.0
+STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2026.1
 
 
 # =============================================================================
-# Build
+# build
 # =============================================================================
 build:
-	mkdir -p $(OUT_DIR)
-	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(OUT_DIR)/ghavm .
+	mkdir -p $(DIST_PATH)
+	GIT_COMMIT=$$(git describe --always --dirty 2>/dev/null || echo "unknown"); \
+	BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ); \
+	CGO_ENABLED=0; \
+	go build -ldflags="-s -w -X main.commit=$$GIT_COMMIT -X main.buildDate=$$BUILD_DATE" -o $(DIST_PATH)/ghavm .
 .PHONY: build
 
 clean:
-	rm -rf $(OUT_DIR) $(DIST_DIR) $(COVERAGE_PATH)
+	rm -rf $(DIST_PATH) $(COVERAGE_PATH)
 .PHONY: clean
 
 
 # =============================================================================
-# Run (shortcut to quickly run against test data)
+# run locally (shortcut to quickly run against test data)
 # =============================================================================
 run: build
-	$(OUT_DIR)/ghavm list ./testdata/workflows
+	$(DIST_PATH)/ghavm list ./testdata/workflows
 .PHONY: run
 
 
-# ===========================================================================
-# Tests
-# ===========================================================================
+# =============================================================================
+# test
+# =============================================================================
 test:
 	go test $(TEST_ARGS) ./...
 .PHONY: test
@@ -58,20 +58,21 @@ testcover: testci
 
 test-reset-golden-fixtures: build
 	PATH="$(shell readlink -f $(OUT_DIR)):$$PATH" ./testdata/bin/reset-golden-fixtures
+.PHONY: test-reset-golden-fixtures
 
 
 # ===========================================================================
-# Linting/formatting
+# linting/formatting
 # ===========================================================================
 lint:
-	test -z "$$($(CMD_GOFUMPT) -d -e .)" || (echo "Error: gofmt failed"; $(CMD_GOFUMPT) -d -e . ; exit 1)
+	$(GOFUMPT) -d .
 	go vet ./...
-	$(CMD_REVIVE) -set_exit_status ./...
-	$(CMD_STATICCHECK) ./...
+	$(REVIVE) -set_exit_status ./...
+	$(STATICCHECK) ./...
 .PHONY: lint
 
 fmt:
-	$(CMD_GOFUMPT) -d -e -w .
+	$(GOFUMPT) -w .
 .PHONY: fmt
 
 
@@ -96,23 +97,10 @@ fmt:
 # [1]: https://github.com/anchore/quill/blob/main/README.md#usage
 # [2]: https://goreleaser.com/customization/notarize/
 # ===========================================================================
-release-dry-run: clean
-	$(CMD_GORELEASER) release --snapshot --clean --verbose
-.PHONY: release-dry-run
-
 release: clean
-	$(CMD_GORELEASER) release --clean
+	$(GORELEASER) release --clean --verbose
 .PHONY: release
 
-release-notarize:
-	$(CMD_QUILL) sign-and-notarize $(DIST_DIR)/ghavm_darwin_all/ghavm
-
-# TAGS should be a space-separated list of image tags to sign (generally
-# provided by the docker/metadata-action step in release.yaml) and DIGEST
-# should be the digest of the image to which all of the tags point.
-#
-# Like the targets above, this step is generally run in the context of the
-# release.yaml GitHub Actions workflow.
-release-sign-images:
-	$(CMD_COSIGN) sign --yes $(foreach tag,$(TAGS),$(tag)@$(DIGEST))
-.PHONY: release-sign-images
+release-dry-run: clean
+	$(GORELEASER) release --clean --verbose --snapshot
+.PHONY: release-dry-run

--- a/main.go
+++ b/main.go
@@ -11,12 +11,13 @@ import (
 
 // Release information populated by goreleaser at build time
 var (
-	version = "dev"
-	commit  = "unknown"
+	version   = "dev"
+	commit    = "unknown"
+	buildDate = "unknown"
 )
 
 func main() {
-	versionInfo := fmt.Sprintf("ghavm version %s %s %s", version, commit, runtime.Version())
+	versionInfo := fmt.Sprintf("ghavm version %s %s %s (built %s)", version, commit, runtime.Version(), buildDate)
 	app := ghavm.NewApp(os.Stdin, os.Stdout, os.Stderr, os.Getenv, versionInfo)
 	if err := ghavm.RunApp(app, os.Args[1:]); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Pick up revamped release workflow from [mccutchen/go-app-template](https://github.com/mccutchen/go-app-template) that builds release artifacts and docker images all via goreleaser, with as many build provenance features as I could figure out how to enable.